### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -1,4 +1,6 @@
 name: Qodana
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/DevNergis/sqla.re/security/code-scanning/1](https://github.com/DevNergis/sqla.re/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Since the workflow performs a Qodana scan, it likely only needs read access to the repository contents. We will set `contents: read` as the permission. This change will ensure that the workflow does not inherit unnecessary permissions, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
